### PR TITLE
Fix custom data_directory mode

### DIFF
--- a/recipes/server_redhat.rb
+++ b/recipes/server_redhat.rb
@@ -44,6 +44,7 @@ directory node['postgresql']['config']['data_directory'] do
   group "postgres"
   recursive true
   action :create
+  mode "0700"
 end
 
 node['postgresql']['server']['packages'].each do |pg_pack|


### PR DESCRIPTION
When defining a custom data_directory, the permissions should be 0700. Otherwhise postgres won't start & whine about a world-readable data-directory.
